### PR TITLE
upgrade with clean policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,31 +8,41 @@ on:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.2', '8.3']
+        dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      
-      - uses: shivammathur/setup-php@2.10.0
+
+      - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
-      
+          php-version: ${{ matrix.php-versions }}
+
       - run: composer validate --strict
-      
-      - run: composer install --prefer-dist --no-progress --no-suggest
-      
+
+      - uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+
       - run: vendor/bin/phpcs
+        if: ${{ failure() ||  success() }}
 
       - run: vendor/bin/phpstan
+        if: ${{ failure() ||  success() }}
 
       - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover ./clover.xml --log-junit ./phpunit.report.xml
-      
+        if: ${{ failure() ||  success() }}
+
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747
       # $GITHUB_WORKSPACE contains a slash so @ is used as delimiter
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' clover.xml
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.report.xml
-      
+
       - uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,8 @@
       "AssoConnect\\LinxoClient\\Tests\\": "tests/"
     }
   },
-  "require-dev": {
-    "phpunit/phpunit": "^9.2",
-    "squizlabs/php_codesniffer": "^3",
-    "assoconnect/phpstan-rules": "^1.0"
-  },
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^7.4|^8.2|^8.3",
     "league/oauth2-client": "^2.6",
     "guzzlehttp/guzzle": "^6.0|^7.4",
     "koriym/http-constants": "^1.2",
@@ -35,5 +30,13 @@
     "moneyphp/money": "^3.0|^4.0",
     "assoconnect/php-date": "^2.2",
     "symfony/translation": "^5.4|^6.0|^7.0"
+  },
+  "require-dev": {
+    "assoconnect/php-quality-config": "^1.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     "guzzlehttp/guzzle": "^7.4",
     "koriym/http-constants": "^1.2",
     "ext-json": "*",
-    "moneyphp/money": "^3.0|^4.0",
+    "moneyphp/money": "^3.3|^4.0",
     "assoconnect/php-date": "^2.2",
     "symfony/translation": "^5.4|^6.0|^7.0"
   },
   "require-dev": {
-    "assoconnect/php-quality-config": "^1.0"
+    "assoconnect/php-quality-config": "^1.14"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^7.4|^8.2|^8.3",
     "league/oauth2-client": "^2.6",
-    "guzzlehttp/guzzle": "^6.0|^7.4",
+    "guzzlehttp/guzzle": "^7.4",
     "koriym/http-constants": "^1.2",
     "ext-json": "*",
     "moneyphp/money": "^3.0|^4.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,5 +5,4 @@ parameters:
         - tests/
 
 includes:
-    - vendor/assoconnect/phpstan-rules/extension.neon
-    - vendor/assoconnect/phpstan-rules/rules.neon
+    - vendor/assoconnect/php-quality-config/phpstan.extension.neon

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -50,7 +50,7 @@ class ApiClient
      */
     public function getConnections(): iterable
     {
-        return array_map(function ($connection): ConnectionDto {
+        return array_map(static function (array $connection): ConnectionDto {
             return new ConnectionDto($connection);
         }, $this->request('/connections'));
     }
@@ -66,7 +66,7 @@ class ApiClient
      */
     public function getAccounts(): iterable
     {
-        return array_map(function ($account): AccountDto {
+        return array_map(static function (array $account): AccountDto {
             return new AccountDto($account);
         }, $this->request('/accounts'));
     }
@@ -105,7 +105,7 @@ class ApiClient
         }
 
         $transactions = $this->request('/transactions', $query);
-        return array_map(function ($transaction): TransactionDto {
+        return array_map(static function (array $transaction): TransactionDto {
             return new TransactionDto($transaction);
         }, $transactions);
     }

--- a/src/Dto/AccountDto.php
+++ b/src/Dto/AccountDto.php
@@ -8,6 +8,18 @@ use Money\Currency;
 use Money\Money;
 use Symfony\Component\Translation\TranslatableMessage;
 
+/**
+ * @phpstan-type Account array{
+ *     id: string,
+ *     connection_id: string,
+ *     name?: string,
+ *     account_number?: string,
+ *     iban?: string,
+ *     status: string,
+ *     currency: string,
+ *     balance: string
+ * }
+ */
 class AccountDto
 {
     private string $id;
@@ -34,7 +46,7 @@ class AccountDto
     public const STATUS_PENDING_CONSENT = 'PENDING_CONSENT';
 
     /**
-     * @param mixed[] $data
+     * @param Account $data
      */
     public function __construct(array $data)
     {
@@ -44,7 +56,7 @@ class AccountDto
         $this->iban = $data['iban'] ?? null;
         $this->status = $data['status'];
         $this->currency = new Currency($data['currency']);
-        $this->balance = new Money(intval(round($data['balance'] * 100)), $this->currency);
+        $this->balance = new Money(intval(round((float) $data['balance'] * 100)), $this->currency);
         $this->data = $data;
     }
 
@@ -90,7 +102,7 @@ class AccountDto
 
     /**
      * @codeCoverageIgnore
-     * @return mixed[]
+     * @return Account
      */
     public function getData(): array
     {

--- a/src/Dto/TransactionDto.php
+++ b/src/Dto/TransactionDto.php
@@ -7,8 +7,19 @@ namespace AssoConnect\LinxoClient\Dto;
 use AssoConnect\PHPDate\AbsoluteDate;
 use Money\Currency;
 use Money\Money;
-use Symfony\Component\Translation\TranslatableMessage;
 
+/**
+ * @phpstan-type Transaction array{
+ *     id: string,
+ *     account_id: string,
+ *     amount: string,
+ *     currency: string,
+ *     label?: string,
+ *     notes?: string,
+ *     type: string,
+ *     date: string
+ * }
+ */
 class TransactionDto
 {
     private string $id;
@@ -48,20 +59,20 @@ class TransactionDto
     public const TIMEZONE = 'Europe/Paris';
 
     /**
-     * @param mixed[] $data
+     * @param Transaction $data
      */
     public function __construct(array $data)
     {
         $this->id = $data['id'];
         $this->accountId = $data['account_id'];
-        $this->amount = new Money(intval(round($data['amount'] * 100)), new Currency($data['currency']));
+        $this->amount = new Money(intval(round((float) $data['amount'] * 100)), new Currency($data['currency']));
         $this->label = $data['label'] ?? null;
         $this->notes = $data['notes'] ?? null;
         $this->type = $data['type'];
         $this->date = AbsoluteDate::createInTimezone(
         // Linxo uses timestamps but their servers' timezone is Europe/Paris
             new \DateTimeZone(self::TIMEZONE),
-            new \DateTime('@' . $data['date'])
+            new \DateTimeImmutable('@' . $data['date'])
         );
         $this->data = $data;
     }
@@ -103,7 +114,7 @@ class TransactionDto
 
     /**
      * @codeCoverageIgnore
-     * @return mixed[]
+     * @return Transaction
      */
     public function getData(): array
     {


### PR DESCRIPTION
- Update the build file using https://www.notion.so/assoconnect/Clean-Policy-before-coding-a-change-on-our-Open-Source-packages-321e910660cc4f7eb3f5d37f0a42adc7
- I let php 7.4 as an acceptable version in composer but it's no longer tested in CI
- I set Minimal moneyphp/money to 3.3 because of the `Money::EUR()` dynamic static call was not available before
- I set the minimal version of assoconnect/php-quality-config to 1.14 to be able to use vendor/assoconnect/php-quality-config/phpstan.extension.neon
- I used static in callback when it was possible
- Fixed some PHPStan issues (level 6 as before):
  - I add PHPStan typed array for `Transaction` and `Account`
  - cast string as float before a mathematical operation
  - use DateTimeImmutable

Ticket: https://assoconnect.atlassian.net/browse/AN-18184