### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": "^7.4|^8.2|^8.3",
+    "php": "^8.3",
     "league/oauth2-client": "^2.6",
     "guzzlehttp/guzzle": "^7.4",
     "koriym/http-constants": "^1.2",

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -90,8 +90,8 @@ class ApiClient
     public function getTransactions(
         string $accountId,
         int $page = 1,
-        AbsoluteDate $startDate = null,
-        AbsoluteDate $endDate = null,
+        ?AbsoluteDate $startDate = null,
+        ?AbsoluteDate $endDate = null,
         int $limit = 100
     ): array {
         $query = [
@@ -120,8 +120,8 @@ class ApiClient
      */
     public function getTransactionsIterator(
         string $accountId,
-        AbsoluteDate $startDate = null,
-        AbsoluteDate $endDate = null
+        ?AbsoluteDate $startDate = null,
+        ?AbsoluteDate $endDate = null
     ): TransactionIterator {
         return new TransactionIterator($this, $accountId, $startDate, $endDate);
     }

--- a/src/Iterator/TransactionIterator.php
+++ b/src/Iterator/TransactionIterator.php
@@ -31,8 +31,8 @@ class TransactionIterator implements \Iterator
     public function __construct(
         ApiClient $apiClient,
         string $accountId,
-        AbsoluteDate $startDate = null,
-        AbsoluteDate $endDate = null
+        ?AbsoluteDate $startDate = null,
+        ?AbsoluteDate $endDate = null
     ) {
         $this->apiClient = $apiClient;
         $this->accountId = $accountId;


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4