### PR TITLE
Fix bad account_ids filtering 

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -96,7 +96,7 @@ class ApiClient
     ): array {
         $query = [
             'user_id' => $this->userId,
-            'account_ids' => [$accountId],
+            'account_ids' => $accountId,
             'page' => $page,
             'limit' => $limit
         ];


### PR DESCRIPTION
Fix bad filtering using guzzlehttp thought http_build_query which encode querystring. This was not understand by Linxo.

Before: 
`https://api.oxlin.io/v3/transactions?user_id=123456&account_ids%5B0%5D=465789&start_date=2026-01-01T00%3A00%3A00%2B01%3A00&page=1&limit=100`

After:
`https://api.oxlin.io/v3/transactions?user_id=123456&account_ids=465789&start_date=2026-01-01T00%3A00%3A00%2B01%3A00&page=1&limit=100`