### PR TITLE
Remove support for Symfony 6 and lower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "ext-json": "*",
     "moneyphp/money": "^3.3|^4.0",
     "assoconnect/php-date": "^2.2",
-    "symfony/translation": "^5.4|^6.0|^7.0"
+    "symfony/translation": "^7.0"
   },
   "require-dev": {
     "assoconnect/php-quality-config": "^2"


### PR DESCRIPTION
## Summary
- Update symfony/translation constraint to require ^7.0 only
- Drop support for Symfony 5.x and 6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)