### PR TITLE
Use self::assert* instead of $this->assert* in tests

### DIFF
--- a/tests/Dto/AccountDtoTest.php
+++ b/tests/Dto/AccountDtoTest.php
@@ -30,11 +30,11 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('acc-123', $dto->getId());
-        $this->assertSame('conn-456', $dto->getConnectionId());
-        $this->assertSame('My Checking Account', $dto->getName());
-        $this->assertSame('FR7630001007941234567890185', $dto->getIban());
-        $this->assertSame(AccountDto::STATUS_ACTIVE, $dto->getStatus());
+        self::assertSame('acc-123', $dto->getId());
+        self::assertSame('conn-456', $dto->getConnectionId());
+        self::assertSame('My Checking Account', $dto->getName());
+        self::assertSame('FR7630001007941234567890185', $dto->getIban());
+        self::assertSame(AccountDto::STATUS_ACTIVE, $dto->getStatus());
     }
 
     public function testBalanceConvertedToMoneyInCents(): void
@@ -48,10 +48,10 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertInstanceOf(Money::class, $dto->getBalance());
-        $this->assertSame('123456', $dto->getBalance()->getAmount());
-        $this->assertInstanceOf(Currency::class, $dto->getCurrency());
-        $this->assertSame('EUR', $dto->getCurrency()->getCode());
+        self::assertInstanceOf(Money::class, $dto->getBalance());
+        self::assertSame('123456', $dto->getBalance()->getAmount());
+        self::assertInstanceOf(Currency::class, $dto->getCurrency());
+        self::assertSame('EUR', $dto->getCurrency()->getCode());
     }
 
     public function testBalanceWithZeroAmount(): void
@@ -65,7 +65,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('0', $dto->getBalance()->getAmount());
+        self::assertSame('0', $dto->getBalance()->getAmount());
     }
 
     public function testBalanceWithNegativeAmount(): void
@@ -79,7 +79,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('-50025', $dto->getBalance()->getAmount());
+        self::assertSame('-50025', $dto->getBalance()->getAmount());
     }
 
     public function testBalanceRoundingWithMoreThanTwoDecimals(): void
@@ -93,7 +93,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('10100', $dto->getBalance()->getAmount());
+        self::assertSame('10100', $dto->getBalance()->getAmount());
     }
 
     public function testNameFallsBackToAccountNumber(): void
@@ -106,7 +106,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('FR76123456789', $dto->getName());
+        self::assertSame('FR76123456789', $dto->getName());
     }
 
     public function testNameUsedWhenProvided(): void
@@ -118,7 +118,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame('Primary Account', $dto->getName());
+        self::assertSame('Primary Account', $dto->getName());
     }
 
     public function testIbanIsNullWhenNotProvided(): void
@@ -128,7 +128,7 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertNull($dto->getIban());
+        self::assertNull($dto->getIban());
     }
 
     public function testDifferentCurrencies(): void
@@ -145,7 +145,7 @@ class AccountDtoTest extends TestCase
 
             $dto = new AccountDto($data);
 
-            $this->assertSame($currencyCode, $dto->getCurrency()->getCode());
+            self::assertSame($currencyCode, $dto->getCurrency()->getCode());
         }
     }
 
@@ -156,9 +156,9 @@ class AccountDtoTest extends TestCase
         $dto = new AccountDto($data);
         $message = $dto->getLocalizedStatus();
 
-        $this->assertInstanceOf(TranslatableMessage::class, $message);
-        $this->assertSame('account_status.ACTIVE', $message->getMessage());
-        $this->assertSame('linxo', $message->getDomain());
+        self::assertInstanceOf(TranslatableMessage::class, $message);
+        self::assertSame('account_status.ACTIVE', $message->getMessage());
+        self::assertSame('linxo', $message->getDomain());
     }
 
     /**
@@ -170,8 +170,8 @@ class AccountDtoTest extends TestCase
 
         $dto = new AccountDto($data);
 
-        $this->assertSame($status, $dto->getStatus());
-        $this->assertSame('account_status.' . $status, $dto->getLocalizedStatus()->getMessage());
+        self::assertSame($status, $dto->getStatus());
+        self::assertSame('account_status.' . $status, $dto->getLocalizedStatus()->getMessage());
     }
 
     /**

--- a/tests/Dto/ConnectionDtoTest.php
+++ b/tests/Dto/ConnectionDtoTest.php
@@ -20,10 +20,10 @@ class ConnectionDtoTest extends TestCase
 
         $dto = new ConnectionDto($data);
 
-        $this->assertSame('conn-123', $dto->getId());
-        $this->assertSame('BNP Paribas', $dto->getName());
-        $this->assertSame(ConnectionDto::STATUS_SUCCESS, $dto->getStatus());
-        $this->assertSame('https://example.com/bnp-logo.png', $dto->getLogoUrl());
+        self::assertSame('conn-123', $dto->getId());
+        self::assertSame('BNP Paribas', $dto->getName());
+        self::assertSame(ConnectionDto::STATUS_SUCCESS, $dto->getStatus());
+        self::assertSame('https://example.com/bnp-logo.png', $dto->getLogoUrl());
     }
 
     /**
@@ -35,7 +35,7 @@ class ConnectionDtoTest extends TestCase
 
         $dto = new ConnectionDto($data);
 
-        $this->assertSame($status, $dto->getStatus());
+        self::assertSame($status, $dto->getStatus());
     }
 
     /**
@@ -65,7 +65,7 @@ class ConnectionDtoTest extends TestCase
 
             $dto = new ConnectionDto($data);
 
-            $this->assertSame($bankName, $dto->getName());
+            self::assertSame($bankName, $dto->getName());
         }
     }
 
@@ -82,7 +82,7 @@ class ConnectionDtoTest extends TestCase
 
             $dto = new ConnectionDto($data);
 
-            $this->assertSame($logoUrl, $dto->getLogoUrl());
+            self::assertSame($logoUrl, $dto->getLogoUrl());
         }
     }
 

--- a/tests/Dto/TransactionDtoTest.php
+++ b/tests/Dto/TransactionDtoTest.php
@@ -31,11 +31,11 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame('txn-123', $dto->getId());
-        $this->assertSame('acc-456', $dto->getAccountId());
-        $this->assertSame('Grocery Store Purchase', $dto->getLabel());
-        $this->assertSame('Weekly groceries', $dto->getNotes());
-        $this->assertSame(TransactionDto::TYPE_POINT_OF_SALE, $dto->getType());
+        self::assertSame('txn-123', $dto->getId());
+        self::assertSame('acc-456', $dto->getAccountId());
+        self::assertSame('Grocery Store Purchase', $dto->getLabel());
+        self::assertSame('Weekly groceries', $dto->getNotes());
+        self::assertSame(TransactionDto::TYPE_POINT_OF_SALE, $dto->getType());
     }
 
     public function testAmountConvertedToMoneyInCents(): void
@@ -47,10 +47,10 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertInstanceOf(Money::class, $dto->getAmount());
-        $this->assertSame('123456', $dto->getAmount()->getAmount());
-        $this->assertInstanceOf(Currency::class, $dto->getAmount()->getCurrency());
-        $this->assertSame('EUR', $dto->getAmount()->getCurrency()->getCode());
+        self::assertInstanceOf(Money::class, $dto->getAmount());
+        self::assertSame('123456', $dto->getAmount()->getAmount());
+        self::assertInstanceOf(Currency::class, $dto->getAmount()->getCurrency());
+        self::assertSame('EUR', $dto->getAmount()->getCurrency()->getCode());
     }
 
     public function testAmountWithNegativeValue(): void
@@ -62,7 +62,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame('-9999', $dto->getAmount()->getAmount());
+        self::assertSame('-9999', $dto->getAmount()->getAmount());
     }
 
     public function testAmountWithZeroValue(): void
@@ -74,7 +74,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame('0', $dto->getAmount()->getAmount());
+        self::assertSame('0', $dto->getAmount()->getAmount());
     }
 
     public function testAmountRoundingWithMoreThanTwoDecimals(): void
@@ -86,7 +86,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame('5056', $dto->getAmount()->getAmount());
+        self::assertSame('5056', $dto->getAmount()->getAmount());
     }
 
     public function testTypeFallsBackToOtherWhenNotProvided(): void
@@ -96,7 +96,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame(TransactionDto::TYPE_OTHER, $dto->getType());
+        self::assertSame(TransactionDto::TYPE_OTHER, $dto->getType());
     }
 
     public function testLabelIsNullWhenNotProvided(): void
@@ -106,7 +106,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertNull($dto->getLabel());
+        self::assertNull($dto->getLabel());
     }
 
     public function testNotesIsNullWhenNotProvided(): void
@@ -116,7 +116,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertNull($dto->getNotes());
+        self::assertNull($dto->getNotes());
     }
 
     public function testDateParsedAsAbsoluteDate(): void
@@ -128,13 +128,13 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertInstanceOf(AbsoluteDate::class, $dto->getDate());
-        $this->assertSame('2024-06-20', $dto->getDate()->__toString());
+        self::assertInstanceOf(AbsoluteDate::class, $dto->getDate());
+        self::assertSame('2024-06-20', $dto->getDate()->__toString());
     }
 
     public function testDateUsesEuropeParisTimezone(): void
     {
-        $this->assertSame('Europe/Paris', TransactionDto::TIMEZONE);
+        self::assertSame('Europe/Paris', TransactionDto::TIMEZONE);
 
         // Test a date that would be different in UTC vs Europe/Paris
         // 2024-01-15T23:30:00Z (UTC) is 2024-01-16T00:30:00 in Paris (winter time, UTC+1)
@@ -146,7 +146,7 @@ class TransactionDtoTest extends TestCase
         $dto = new TransactionDto($data);
 
         // In Europe/Paris, this would be the next day
-        $this->assertSame('2024-01-16', $dto->getDate()->__toString());
+        self::assertSame('2024-01-16', $dto->getDate()->__toString());
     }
 
     public function testDifferentCurrencies(): void
@@ -161,7 +161,7 @@ class TransactionDtoTest extends TestCase
 
             $dto = new TransactionDto($data);
 
-            $this->assertSame($currencyCode, $dto->getAmount()->getCurrency()->getCode());
+            self::assertSame($currencyCode, $dto->getAmount()->getCurrency()->getCode());
         }
     }
 
@@ -174,7 +174,7 @@ class TransactionDtoTest extends TestCase
 
         $dto = new TransactionDto($data);
 
-        $this->assertSame($type, $dto->getType());
+        self::assertSame($type, $dto->getType());
     }
 
     /**

--- a/tests/Dto/UserDtoTest.php
+++ b/tests/Dto/UserDtoTest.php
@@ -22,12 +22,12 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertSame('user-123', $dto->getId());
-        $this->assertSame('john.doe@example.com', $dto->getEmail());
-        $this->assertSame('John', $dto->getFirstname());
-        $this->assertSame('Doe', $dto->getLastname());
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dto->getCreatedAt());
-        $this->assertSame($creationTimestamp, $dto->getCreatedAt()->getTimestamp());
+        self::assertSame('user-123', $dto->getId());
+        self::assertSame('john.doe@example.com', $dto->getEmail());
+        self::assertSame('John', $dto->getFirstname());
+        self::assertSame('Doe', $dto->getLastname());
+        self::assertInstanceOf(\DateTimeImmutable::class, $dto->getCreatedAt());
+        self::assertSame($creationTimestamp, $dto->getCreatedAt()->getTimestamp());
     }
 
     public function testFirstnameIsNullWhenNotProvided(): void
@@ -37,7 +37,7 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertNull($dto->getFirstname());
+        self::assertNull($dto->getFirstname());
     }
 
     public function testLastnameIsNullWhenNotProvided(): void
@@ -47,7 +47,7 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertNull($dto->getLastname());
+        self::assertNull($dto->getLastname());
     }
 
     public function testBothNamesNullWhenNotProvided(): void
@@ -57,8 +57,8 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertNull($dto->getFirstname());
-        $this->assertNull($dto->getLastname());
+        self::assertNull($dto->getFirstname());
+        self::assertNull($dto->getLastname());
     }
 
     public function testCreatedAtParsedFromUnixTimestamp(): void
@@ -68,8 +68,8 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertSame('2021-01-01', $dto->getCreatedAt()->format('Y-m-d'));
-        $this->assertSame($timestamp, $dto->getCreatedAt()->getTimestamp());
+        self::assertSame('2021-01-01', $dto->getCreatedAt()->format('Y-m-d'));
+        self::assertSame($timestamp, $dto->getCreatedAt()->getTimestamp());
     }
 
     public function testCreatedAtWithRecentTimestamp(): void
@@ -79,7 +79,7 @@ class UserDtoTest extends TestCase
 
         $dto = new UserDto($data);
 
-        $this->assertSame('2024-01-01', $dto->getCreatedAt()->format('Y-m-d'));
+        self::assertSame('2024-01-01', $dto->getCreatedAt()->format('Y-m-d'));
     }
 
     public function testEmailWithVariousFormats(): void
@@ -96,7 +96,7 @@ class UserDtoTest extends TestCase
 
             $dto = new UserDto($data);
 
-            $this->assertSame($email, $dto->getEmail());
+            self::assertSame($email, $dto->getEmail());
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `$this->assert*` with `self::assert*` in all test files, as recommended by Rector (static calls are preferred for PHPUnit assertions)

## Test plan
- [ ] All 62 tests pass locally
- [ ] CI passes on highest and lowest builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)