### PR TITLE
Require PHP 8.4 and add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4', '8.5']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": "^8.3",
+    "php": "^8.4",
     "league/oauth2-client": "^2.6",
     "guzzlehttp/guzzle": "^7.4",
     "koriym/http-constants": "^1.2",


### PR DESCRIPTION
## Summary
- Bump minimum PHP requirement from `^8.3` to `^8.4` in `composer.json`
- Replace PHP 8.3 with PHP 8.5 in the CI test matrix (keeping PHP 8.4)

## Test plan
- [ ] CI passes on PHP 8.4 and 8.5 with lowest/highest dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)